### PR TITLE
Drop `CUDA_HOME` from `script_env`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,9 +14,6 @@ build:
   skip: true  # [(linux or win) and (cuda_compiler_version != "11.2")]
   ignore_run_exports_from:
     - {{ compiler('cuda') }}  # [not osx]
-  script_env:
-    # for some reason /usr/local/cuda is not added to $PATH in the docker image
-    - CUDA_HOME  # [ppc64le or aarch64]
 
 requirements:
   build:


### PR DESCRIPTION
This was a workaround due to CUDA tools not being added to the path in arch images. Now that this is fixed in the images, drop this workaround from the recipe.

xref: https://github.com/conda-forge/docker-images/pull/210

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
